### PR TITLE
Add `brew json` command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: GitHub Actions CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: macos-latest
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - run: brew style $GITHUB_REPOSITORY
+
+      - run: brew json hello

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - run: brew install-bundler-gems
+
       - run: brew style $GITHUB_REPOSITORY
 
       - run: brew json hello

--- a/cmd/json.rb
+++ b/cmd/json.rb
@@ -1,0 +1,137 @@
+# typed: true
+# frozen_string_literal: true
+
+require "formula_installer"
+
+module Homebrew
+  extend T::Sig
+
+  module_function
+
+  FORMULAE_BREW_SH_BOTTLE_API_DOMAIN = Pathname.new("https://formulae.brew.sh/api/bottle").freeze
+  GITHUB_PACKAGES_SHA256_REGEX = %r{#{GitHubPackages::URL_REGEX}.*/blobs/sha256:(?<sha256>\h{64})$}.freeze
+
+  sig { returns(CLI::Parser) }
+  def json_args
+    Homebrew::CLI::Parser.new do
+      description <<~EOS
+        Install a <formula> from a JSON file.
+
+        A <formula> can be specified by name, a JSON file, or a URL.
+      EOS
+
+      named_args [:formula, :file, :url], min: 1
+    end
+  end
+
+  sig { void }
+  def json
+    args = json_args.parse
+
+    args.named.each do |arg|
+      json = if File.exist? arg
+        File.read(arg)
+      else
+        arg = FORMULAE_BREW_SH_BOTTLE_API_DOMAIN/"#{arg}.json" unless arg.start_with? %r{https?://}
+
+        output = curl_output("--fail", arg.to_s)
+        odie "No JSON file found at #{Tty.underline}#{arg}#{Tty.reset}" unless output.success?
+
+        output.stdout
+      end
+
+      hash = JSON.parse(json)
+      name = hash["name"]
+      bottles = download_bottles hash
+
+      formula = Formulary.factory bottles[name]
+      install_formula formula, args: install_args(args: args)
+    end
+  end
+
+  sig { params(url: String).returns(T.nilable(String)) }
+  def checksum_from_url(url)
+    match = url.match GITHUB_PACKAGES_SHA256_REGEX
+    return if match.blank?
+
+    match[:sha256]
+  end
+
+  sig { params(hash: Hash).returns(T::Hash[String, Pathname]) }
+  def download_bottles(hash)
+    bottle_tag = Utils::Bottles.tag.to_s
+    bottles = {}
+
+    odie "No bottle availabe for current OS" unless hash["bottles"].key? bottle_tag
+
+    bottles[hash["name"]] = download_bottle(hash, bottle_tag)
+
+    hash["dependencies"].each do |dep_hash|
+      bottles[dep_hash["name"]] = download_bottle(dep_hash, bottle_tag)
+    end
+
+    bottles
+  end
+
+  sig { params(hash: Hash, tag: String).returns(Pathname) }
+  def download_bottle(hash, tag)
+    bottle = hash["bottles"][tag]
+    return if bottle.blank?
+
+    sha256 = bottle["sha256"] || checksum_from_url(bottle["url"])
+    bottle_filename = Bottle::Filename.new(hash["name"], hash["pkg_version"], tag, hash["rebuild"])
+
+    resource = Resource.new hash["name"]
+    resource.url bottle["url"]
+    resource.sha256 sha256
+    resource.downloader.resolved_basename = bottle_filename
+
+    resource.fetch
+  end
+
+  def install_args(args:)
+    result = OpenStruct.new
+    result[:debug] = args.debug?
+    result[:quiet] = args.quiet?
+    result[:verbose] = args.verbose?
+    result
+  end
+
+  # Copied directly from the install command
+  def install_formula(f, args:)
+    f.print_tap_action
+    build_options = f.build
+
+    fi = FormulaInstaller.new(
+      f,
+      **{
+        options:                    build_options.used_options,
+        build_bottle:               args.build_bottle?,
+        force_bottle:               args.force_bottle?,
+        bottle_arch:                args.bottle_arch,
+        ignore_deps:                args.ignore_dependencies?,
+        only_deps:                  args.only_dependencies?,
+        include_test_formulae:      args.include_test_formulae,
+        build_from_source_formulae: args.build_from_source_formulae,
+        cc:                         args.cc,
+        git:                        args.git?,
+        interactive:                args.interactive?,
+        keep_tmp:                   args.keep_tmp?,
+        force:                      args.force?,
+        debug:                      args.debug?,
+        quiet:                      args.quiet?,
+        verbose:                    args.verbose?,
+      }.compact,
+    )
+    fi.prelude
+    fi.fetch
+    fi.install
+    fi.finish
+  rescue FormulaInstallationAlreadyAttemptedError
+    # We already attempted to install f as part of the dependency tree of
+    # another formula. In that case, don't generate an error, just move on.
+    nil
+  rescue CannotInstallFormulaError => e
+    ofail e.message
+  end
+end

--- a/cmd/json.rb
+++ b/cmd/json.rb
@@ -40,7 +40,12 @@ module Homebrew
         output.stdout
       end
 
-      hash = JSON.parse(json)
+      begin
+        hash = JSON.parse(json)
+      rescue JSON::ParserError
+        odie "Invalid JSON file: #{Tty.underline}#{arg}#{Tty.reset}"
+      end
+
       name = hash["name"]
       bottles = download_bottles hash
 


### PR DESCRIPTION
This PR adds the first version of the `brew json` command.

So far, this command works on a formula without any dependencies when installing from a local JSON file. I've needed to update the bottle JSON a bit (which I've done in https://github.com/Homebrew/brew/pull/11516) and once that gets through formulae.brew.sh installing from a URL or with just the name should work fine.

To test this out, run `brew json hello`

The things that currently work:
1. The bottles for the formula and its dependencies are downloaded
2. The formula file is loaded from the downloaded bottle
3. The bottle can be installed

At the moment, the biggest things that are missing are the following:

1. There doesn't seem to be any of the typical `brew install` output other than the download output for the bottles and a message at the end
2. None of the pre-install checks are run
3. There's no cleanup run after
4. Dependencies are still taken from homebrew/core, not from the newly downloaded bottles

There are other things to do, but the above are the first things I need to look at.
