### PR TITLE
Improve dependency handling

### DIFF
--- a/cmd/json.rb
+++ b/cmd/json.rb
@@ -50,8 +50,8 @@ module Homebrew
       end
 
       name = hash["name"]
-      bottles = download_bottles hash
-      formula = Formulary.factory(bottles[name])
+      download_bottles hash
+      formula = Formulary.factory(name)
 
       formula if Install.install_formula? formula, force: args.force?, quiet: args.quiet?
     end.compact
@@ -96,17 +96,14 @@ module Homebrew
 
   def download_bottles(hash)
     bottle_tag = Utils::Bottles.tag.to_s
-    bottles = {}
 
     odie "No bottle availabe for current OS" unless hash["bottles"].key? bottle_tag
 
-    bottles[hash["name"]] = download_bottle(hash, bottle_tag)
+    download_bottle(hash, bottle_tag)
 
     hash["dependencies"].each do |dep_hash|
-      bottles[dep_hash["name"]] = download_bottle(dep_hash, bottle_tag)
+      download_bottle(dep_hash, bottle_tag)
     end
-
-    bottles
   end
 
   def download_bottle(hash, tag)
@@ -122,11 +119,11 @@ module Homebrew
     resource.version hash["pkg_version"]
     resource.downloader.resolved_basename = bottle_filename
 
+    resource.fetch
+
     # Map the name of this formula to the local bottle path to allow the
     # formula to be loaded by passing just the name to `Formulary::factory`.
     ENV["HOMEBREW_BOTTLE_JSON"] = "1"
     Formulary.map_formula_name_to_local_bottle_path hash["name"], resource.downloader.cached_location
-
-    resource.fetch
   end
 end


### PR DESCRIPTION
This PR improves the ways that dependencies are handled.

Now, the only dependencies that can be loaded from the caches bottle in the way that is done here are those that were downloaded by this `json` run (this includes cached downloads). This feels a bit safer and is a more reliable way of getting the correct dependency versions to be used.

This also uses the direct `HOMEBREW_CACHE/downloads/...` file instead of following the link from the main `HOMEBREW_CACHE` directory.

I also feel that this is a slightly less hacky way to do this (even though it still uses monkey patching) as the only formulae that can be loaded in this was are the ones recently downloaded (and these are specified directly to the `Formulary` class)
