### PR TITLE
Set `HOMEBREW_JSON_CORE` environment variable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
       - main
   pull_request:
 env:
+  HOMEBREW_DEVELOPER: 1
   HOMEBREW_JSON_CORE: 1
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+env:
+  HOMEBREW_JSON_CORE: 1
 
 jobs:
   tests:
@@ -15,5 +17,7 @@ jobs:
       - run: brew install-bundler-gems
 
       - run: brew style $GITHUB_REPOSITORY
+
+      - run: brew untap homebrew/core
 
       - run: brew json hello

--- a/cmd/json.rb
+++ b/cmd/json.rb
@@ -31,6 +31,8 @@ module Homebrew
   def json
     args = json_args.parse
 
+    ENV["HOMEBREW_JSON_CORE"] = "1"
+
     formulae = args.named.map do |arg|
       json = if File.exist? arg
         File.read(arg)
@@ -123,7 +125,6 @@ module Homebrew
 
     # Map the name of this formula to the local bottle path to allow the
     # formula to be loaded by passing just the name to `Formulary::factory`.
-    ENV["HOMEBREW_BOTTLE_JSON"] = "1"
     Formulary.map_formula_name_to_local_bottle_path hash["name"], resource.downloader.cached_location
   end
 end


### PR DESCRIPTION
Use new variable and untap homebrew/core when testing in CI. This needs to wait for https://github.com/Homebrew/brew/pull/11555 to be merged.

This also moves the setting of the variable higher up because it only needs to be done once and can be set for the entire execution.
